### PR TITLE
Add generation timestamps in admin question table

### DIFF
--- a/admin/src/components/theme/ThemeForm.tsx
+++ b/admin/src/components/theme/ThemeForm.tsx
@@ -655,6 +655,11 @@ const ThemeForm: FC<ThemeFormProps> = ({ theme, isEdit = false }) => {
                           >
                             表示
                           </button>
+                          {question.latestVisualReportAt && (
+                            <div className="text-xs text-muted-foreground mt-1">
+                              {formatDate(question.latestVisualReportAt)}
+                            </div>
+                          )}
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap text-sm">
                           <button
@@ -699,6 +704,11 @@ const ThemeForm: FC<ThemeFormProps> = ({ theme, isEdit = false }) => {
                               "更新する"
                             )}
                           </button>
+                          {question.latestDebateAnalysisAt && (
+                            <div className="text-xs text-muted-foreground mt-1">
+                              {formatDate(question.latestDebateAnalysisAt)}
+                            </div>
+                          )}
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap text-sm">
                           <button
@@ -741,6 +751,11 @@ const ThemeForm: FC<ThemeFormProps> = ({ theme, isEdit = false }) => {
                               "更新する"
                             )}
                           </button>
+                          {question.latestReportExampleAt && (
+                            <div className="text-xs text-muted-foreground mt-1">
+                              {formatDate(question.latestReportExampleAt)}
+                            </div>
+                          )}
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap text-sm">
                           <button

--- a/admin/src/services/api/types.ts
+++ b/admin/src/services/api/types.ts
@@ -131,6 +131,9 @@ export interface Question {
   tags?: string[];
   createdAt: string;
   updatedAt: string;
+  latestVisualReportAt?: string | null;
+  latestDebateAnalysisAt?: string | null;
+  latestReportExampleAt?: string | null;
 }
 
 export interface Problem {

--- a/idea-discussion/backend/controllers/questionController.js
+++ b/idea-discussion/backend/controllers/questionController.js
@@ -3,6 +3,8 @@ import Like from "../models/Like.js";
 import Problem from "../models/Problem.js";
 import QuestionLink from "../models/QuestionLink.js";
 import ReportExample from "../models/ReportExample.js";
+import DebateAnalysis from "../models/DebateAnalysis.js";
+import QuestionVisualReport from "../models/QuestionVisualReport.js";
 import SharpQuestion from "../models/SharpQuestion.js";
 import Solution from "../models/Solution.js";
 import { getDebateAnalysis } from "../services/debateAnalysisGenerator.js";
@@ -368,10 +370,37 @@ export const getQuestionsByTheme = async (req, res) => {
   }
 
   try {
-    const questions = await SharpQuestion.find({ themeId }).sort({
-      createdAt: -1,
-    });
-    res.status(200).json(questions);
+    const questions = await SharpQuestion.find({ themeId })
+      .sort({ createdAt: -1 })
+      .lean();
+
+    const questionsWithMeta = await Promise.all(
+      questions.map(async (q) => {
+        const [visual, debate, report] = await Promise.all([
+          QuestionVisualReport.findOne({ questionId: q._id })
+            .sort({ createdAt: -1 })
+            .select("createdAt")
+            .lean(),
+          DebateAnalysis.findOne({ questionId: q._id })
+            .sort({ createdAt: -1 })
+            .select("createdAt")
+            .lean(),
+          ReportExample.findOne({ questionId: q._id })
+            .sort({ createdAt: -1 })
+            .select("createdAt")
+            .lean(),
+        ]);
+
+        return {
+          ...q,
+          latestVisualReportAt: visual ? visual.createdAt : null,
+          latestDebateAnalysisAt: debate ? debate.createdAt : null,
+          latestReportExampleAt: report ? report.createdAt : null,
+        };
+      })
+    );
+
+    res.status(200).json(questionsWithMeta);
   } catch (error) {
     console.error(`Error fetching questions for theme ${themeId}:`, error);
     res.status(500).json({


### PR DESCRIPTION
## Summary
- include latest generation timestamps from DebateAnalysis, ReportExample and QuestionVisualReport in question list API
- expose those optional fields in the admin API types
- display timestamps below each update button in the admin theme screen

## Testing
- `make admin-test` *(fails: vitest not found)*
- `make idea-discussion-backend-test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fe0709f3c8332b8829257036a209a