### PR TITLE
Fix #260: sticky headers for detail pages

### DIFF
--- a/frontend/src/components/theme/ThemeDetailTemplate.tsx
+++ b/frontend/src/components/theme/ThemeDetailTemplate.tsx
@@ -129,14 +129,17 @@ const ThemeDetailTemplate = forwardRef<
 
     return (
       <div className="container mx-auto px-4 py-8">
-        <BreadcrumbView items={breadcrumbItems} />
+        <div className="sticky top-[66px] bg-white z-10 pb-4">
+          <BreadcrumbView items={breadcrumbItems} />
 
-        <h1 className="text-2xl md:text-3xl font-bold mb-4">{theme.title}</h1>
+          <h1 className="text-2xl md:text-3xl font-bold mb-4">{theme.title}</h1>
 
-        <p className="text-base text-muted-foreground mb-8">
-          {theme.description}
-        </p>
+          <p className="text-base text-muted-foreground">
+            {theme.description}
+          </p>
+        </div>
 
+        <div className="mt-8">
         <div className="mb-8">
           <SectionHeading title={`重要論点（${keyQuestions.length}件）`} />
           <div className="space-y-4">
@@ -197,6 +200,8 @@ const ThemeDetailTemplate = forwardRef<
                   />
                 ))}
           </div>
+        </div>
+
         </div>
 
         <FloatingChat

--- a/frontend/src/pages/QuestionDetail.tsx
+++ b/frontend/src/pages/QuestionDetail.tsx
@@ -297,20 +297,23 @@ const QuestionDetail = () => {
     return (
       <>
         <div className="md:mr-[50%]">
-          <div className="container mx-auto px-4 py-8">
-            <BreadcrumbView items={breadcrumbItems} />
+          <div className="sticky top-[66px] bg-white z-10 border-b border-neutral-200">
+            <div className="container mx-auto px-4 py-8">
+              <BreadcrumbView items={breadcrumbItems} />
+              <KeyQuestionHeader
+                question={questionData.question}
+                tagLine={questionData.tagLine}
+                tags={questionData.tags}
+                voteCount={questionData.voteCount}
+                questionId={questionData.id}
+              />
+            </div>
           </div>
-          <KeyQuestionHeader
-            question={questionData.question}
-            tagLine={questionData.tagLine}
-            tags={questionData.tags}
-            voteCount={questionData.voteCount}
-            questionId={questionData.id}
-          />
-          <DebateSummary
-            debateData={debateData}
-            visualReport={questionDetail?.visualReport}
-          />
+          <div className="container mx-auto px-4 py-8">
+            <DebateSummary
+              debateData={debateData}
+              visualReport={questionDetail?.visualReport}
+            />
           <div className="mb-8">
             <div className="flex justify-between items-center mb-4">
               <div className="flex-grow">


### PR DESCRIPTION
## Summary
- keep breadcrumbs and header fixed when scrolling
- apply sticky style for ThemeDetail and QuestionDetail pages

## Testing
- `npm test --workspace frontend` *(fails: vitest not found)*
- `npm run lint --workspace frontend` *(fails: biome not found)*
- `npm run typecheck --workspace frontend` *(fails: tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_68495b5a817c8332888acd7064f5a516